### PR TITLE
Treat empty CSV cells as unbound SPARQL values

### DIFF
--- a/pytarql/pytarql.py
+++ b/pytarql/pytarql.py
@@ -119,7 +119,12 @@ class PyTarql:
         for row in self._reader:
             if self._cached_headers is None:
                 self._cached_headers = self.var_mapping(row)
-            yield dict((self._cached_headers[k], rdflib.Literal(row[k])) for k in row)
+            yield dict((self._cached_headers[k], rdflib.Literal(row[k])) for k in row if self.is_bound(row[k]))
+
+    @staticmethod
+    def is_bound(value):
+        """Checks whether a value taken from a CSV cell is considered an unbound SPARQL value"""
+        return not re.match(r"^\s*$", value)
 
     @staticmethod
     def parse_args(arguments):


### PR DESCRIPTION
tarql treats empty CSV cells as unbound SPARQL values (see [here](https://github.com/tarql/tarql/blob/b06b4dd0699bd2f664e11f3937bca63d80017d84/src/main/java/org/deri/tarql/CSVParser.java#L106-L112)). This change implements the same behaviour in pyTARQL.